### PR TITLE
use caret dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,14 +43,14 @@
   ],
   "homepage": "https://github.com/bahmutov/csrf-login#readme",
   "dependencies": {
-    "bluebird": "2.9.34",
-    "check-more-types": "2.18.0",
-    "cheerio": "0.19.0",
-    "debug": "2.2.0",
-    "first-existing": "1.0.0",
-    "lazy-ass": "1.3.0",
-    "nconf": "0.7.2",
-    "request": "2.60.0"
+    "bluebird": "^2.9.34",
+    "check-more-types": "^2.18.0",
+    "cheerio": "^0.19.0",
+    "debug": "^2.2.0",
+    "first-existing": "^1.0.0",
+    "lazy-ass": "^1.3.0",
+    "nconf": "^0.7.2",
+    "request": "^2.60.0"
   },
   "devDependencies": {
     "body-parser": "1.15.0",


### PR DESCRIPTION
This allows `npm` to dedupe similar versions between projects.
