### PR TITLE
fix(deps): remove Bluebird and bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,13 +43,12 @@
   ],
   "homepage": "https://github.com/bahmutov/csrf-login#readme",
   "dependencies": {
-    "bluebird": "^2.9.34",
     "check-more-types": "^2.18.0",
-    "cheerio": "^0.19.0",
+    "cheerio": "^0.20.0",
     "debug": "^2.2.0",
     "first-existing": "^1.0.0",
     "lazy-ass": "^1.3.0",
-    "nconf": "^0.7.2",
+    "nconf": "^0.8.0",
     "request": "^2.60.0"
   },
   "devDependencies": {

--- a/src/csrf-login.js
+++ b/src/csrf-login.js
@@ -4,7 +4,6 @@ var check = require('check-more-types');
 var log = require('debug')('csrf');
 var join = require('path').join;
 var request = require('request');
-var Promise = require('bluebird');
 var cheerio = require('cheerio');
 
 function getLoginForm(conf, body) {


### PR DESCRIPTION
`csrf-login` doesn't use any non-native Promise functionality (supported since node 0.12) so I think it's safe to remove the Bluebird dependency. If you disagree, I can bump it instead.
