### PR TITLE
fix(deps): bump cheerio

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "homepage": "https://github.com/bahmutov/csrf-login#readme",
   "dependencies": {
     "check-more-types": "^2.18.0",
-    "cheerio": "^0.20.0",
+    "cheerio": "^0.22.0",
     "debug": "^2.2.0",
     "first-existing": "^1.2.0",
     "lazy-ass": "^1.3.0",


### PR DESCRIPTION
0.20.0 needlessly depended on an old version of jsdom which has [since been removed](https://github.com/cheeriojs/cheerio/commit/79d4e5e6f2d2310eed09b83f6ccfd9e4961aa4b1).
